### PR TITLE
Fix wrapper template keywords quoting

### DIFF
--- a/src/mypy_eppy_builder/templates/common/wrapper/pyproject.toml.jinja2
+++ b/src/mypy_eppy_builder/templates/common/wrapper/pyproject.toml.jinja2
@@ -11,7 +11,7 @@ classifiers = [
     "Typing :: Stubs Only",
     "Programming Language :: Python :: 3",
 ]
-keywords = [{{ package.library_name }}, "typing", "stubs"]
+keywords = ["{{ package.library_name }}", "typing", "stubs"]
 dependencies = []
 
 [build-system]

--- a/tests/test_template_rendering.py
+++ b/tests/test_template_rendering.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from jinja2 import Environment, FileSystemLoader
+
+
+def test_pyproject_keywords(tmp_path: Path) -> None:
+    templates_dir = Path("src/mypy_eppy_builder/templates")
+    env = Environment(
+        loader=FileSystemLoader(templates_dir),
+        trim_blocks=True,
+        lstrip_blocks=True,
+        autoescape=True,
+        keep_trailing_newline=True,
+    )
+    template = env.get_template("types-archetypal/pyproject.toml.jinja2")
+    rendered = template.render(
+        package={
+            "data": {"pypi_name": "archetypal-stubs"},
+            "version": "0.1.0",
+            "description": "desc",
+            "library_name": "archetypal",
+        }
+    )
+    assert 'keywords = ["archetypal", "typing", "stubs"]' in rendered


### PR DESCRIPTION
## Summary
- quote `package.library_name` in the wrapper `pyproject.toml` template
- add test ensuring rendered pyproject has expected keywords

## Testing
- `.venv/bin/python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688ae14c5c3c832bac51cf1ccea13423