### PR TITLE
Preserve camel case when normalizing IDD object names

### DIFF
--- a/src/mypy_eppy_builder/eppy_stubs_generator.py
+++ b/src/mypy_eppy_builder/eppy_stubs_generator.py
@@ -23,7 +23,22 @@ class EppyStubGenerator:
         )
 
     def normalize_classname(self, obj_name: str) -> str:
-        return re.sub(r"[^a-zA-Z0-9]", "_", obj_name.title())
+        """Return a valid Python class name for an IDD object.
+
+        EnergyPlus object names can contain characters such as spaces or
+        colons (e.g. ``BuildingSurface:Detailed``).  The original
+        implementation applied :py:meth:`str.title` which lower-cased
+        characters following an existing capital, producing names like
+        ``Buildingsurface_Detailed``.  That behaviour broke the expected
+        camel-casing of many IDD objects.
+
+        This version simply replaces any non alpha-numeric character with an
+        underscore while preserving the original casing of the remaining
+        characters so the example above becomes
+        ``BuildingSurface_Detailed``.
+        """
+
+        return re.sub(r"[^0-9a-zA-Z]+", "_", obj_name.strip())
 
     def normalize_field_name(self, field_name: str) -> str:
         """Normalize field names using same process as `eppy`."""

--- a/tests/test_stub_generator.py
+++ b/tests/test_stub_generator.py
@@ -177,3 +177,16 @@ def test_generate_stubs_and_overloads(tmp_path: Path) -> None:
     overload_content = _render_idf_template(context)
     assert "def newidfobject(self, key: Literal['ZONE'], **kwargs) -> Zone" in overload_content
     assert "class IDF_23_1(IDF)" in overload_content
+
+
+def test_normalize_classname_preserves_camel_case() -> None:
+    from mypy_eppy_builder.eppy_stubs_generator import (
+        EppyStubGenerator,
+        classname_to_key,
+    )
+
+    generator = EppyStubGenerator("dummy.idd", "out")
+
+    name = "BuildingSurface:Detailed"
+    assert generator.normalize_classname(name) == "BuildingSurface_Detailed"
+    assert classname_to_key("BuildingSurface_Detailed") == "BUILDINGSURFACE:DETAILED"


### PR DESCRIPTION
## Summary
- keep original casing when translating IDD object names into Python class names
- add regression test covering colon-separated object names

## Testing
- `uv run pre-commit run -a`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689796725394833396ed4a12ea23acc5