### PR TITLE
Expose archetypal IDF inheritance in stubs

### DIFF
--- a/src/mypy_eppy_builder/templates/common/idf.pyi.jinja2
+++ b/src/mypy_eppy_builder/templates/common/idf.pyi.jinja2
@@ -12,7 +12,7 @@ IDFObjectsDict = TypedDict('IDFObjectsDict', {
 {% endfor %}
 })
 
-class IDF:
+class IDF{% if base_class %}({{ base_class }}){% endif %}:
 {% for classname, ep_key in overloads %}
     @overload
     def newidfobject(self, key: Literal["{{ ep_key }}"], **kwargs) -> {{ classname }}: ...

--- a/src/mypy_eppy_builder/templates/types-archetypal/src/archetypal-stubs/__init__.pyi.jinja2
+++ b/src/mypy_eppy_builder/templates/types-archetypal/src/archetypal-stubs/__init__.pyi.jinja2
@@ -1,0 +1,3 @@
+from .idfclass import IDF
+
+__all__ = ["IDF"]

--- a/src/mypy_eppy_builder/templates/types-archetypal/src/archetypal-stubs/idfclass/idf.pyi.jinja2
+++ b/src/mypy_eppy_builder/templates/types-archetypal/src/archetypal-stubs/idfclass/idf.pyi.jinja2
@@ -1,1 +1,4 @@
+from geomeppy import IDF as GeomIDF
+
+{% set base_class = "GeomIDF" %}
 {% include "common/idf.pyi.jinja2" with context %}

--- a/tests/test_stub_generator.py
+++ b/tests/test_stub_generator.py
@@ -49,7 +49,11 @@ def _render_idf_template(ctx: dict) -> str:
         lines.append(f"    '{overload['key']}': list[{overload['classname']}],")
     lines.append("})")
     lines.append("")
-    lines.append("class IDF:")
+    base_cls = ctx.get("base_class")
+    if base_cls:
+        lines.append(f"class IDF({base_cls}):")
+    else:
+        lines.append("class IDF:")
     version_cls = ctx.get("version_classname")
     ver = ctx.get("eplus_version")
     if version_cls and ver:

--- a/tests/test_template_rendering.py
+++ b/tests/test_template_rendering.py
@@ -91,6 +91,8 @@ def test_archetypal_idf_extra_methods() -> None:
         classnames=["Zone"],
         overloads=[("Zone", "ZONE")],
     )
+    assert "from geomeppy import IDF as GeomIDF" in rendered
+    assert "class IDF(GeomIDF):" in rendered
     assert "def addidfobject" in rendered
 
 


### PR DESCRIPTION
## Summary
- allow IDF template to specify a base class so inherited methods are available to type checkers
- import and export archetypal IDF from `geomeppy` to surface inherited behavior
- adjust tests for new template behaviour

## Testing
- `pre-commit run --files src/mypy_eppy_builder/templates/common/idf.pyi.jinja2 src/mypy_eppy_builder/templates/types-archetypal/src/archetypal-stubs/idfclass/idf.pyi.jinja2 src/mypy_eppy_builder/templates/types-archetypal/src/archetypal-stubs/__init__.pyi.jinja2 tests/test_template_rendering.py tests/test_stub_generator.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689799a4ca5c83339ba00898b236a17a